### PR TITLE
Read custom template components from config

### DIFF
--- a/dist/bundle.js
+++ b/dist/bundle.js
@@ -77291,13 +77291,17 @@ function (_PureComponent) {
 
 
 
-/* harmony default export */ var _manifest = ({
+
+var defaultTemplates = {
   banner_image: banner_image,
   email_signup: email_signup,
   generic_grid: generic_grid,
   hero_full: hero_full,
   horizontal_divider: horizontal_divider,
   product_grid: product_grid
+};
+/* harmony default export */ var _manifest = (function () {
+  return Object.assign({}, defaultTemplates, lib_config.get().customTemplateComponents);
 });
 // CONCATENATED MODULE: ./node_modules/tslib/tslib.es6.js
 /*! *****************************************************************************
@@ -83980,7 +83984,7 @@ function (_Component) {
 /* concated harmony reexport Logo */__webpack_require__.d(__webpack_exports__, "Logo", function() { return logo; });
 /* concated harmony reexport Rating */__webpack_require__.d(__webpack_exports__, "Rating", function() { return objects_rating; });
 /* concated harmony reexport VariantSelector */__webpack_require__.d(__webpack_exports__, "VariantSelector", function() { return variant_selector; });
-/* concated harmony reexport TemplateComponentsManifest */__webpack_require__.d(__webpack_exports__, "TemplateComponentsManifest", function() { return _manifest; });
+/* concated harmony reexport buildTemplateComponentsManifest */__webpack_require__.d(__webpack_exports__, "buildTemplateComponentsManifest", function() { return _manifest; });
 /* concated harmony reexport LoginForm */__webpack_require__.d(__webpack_exports__, "LoginForm", function() { return login_form; });
 /* concated harmony reexport RegisterForm */__webpack_require__.d(__webpack_exports__, "RegisterForm", function() { return register_form; });
 /* concated harmony reexport SearchBar */__webpack_require__.d(__webpack_exports__, "SearchBar", function() { return search_bar; });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shiftcommerce/shift-react-components",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "main": "dist/bundle.js",
   "license": "MIT",
   "scripts": {

--- a/src/components/template-components/_manifest.js
+++ b/src/components/template-components/_manifest.js
@@ -5,7 +5,9 @@ import HeroFull from './hero-full'
 import HorizontalDivider from './horizontal-divider'
 import ProductGrid from './product-grid'
 
-export default {
+import Config from '../../lib/config'
+
+const defaultTemplates = {
   banner_image: BannerImage,
   email_signup: EmailSignup,
   generic_grid: GenericGrid,
@@ -13,3 +15,5 @@ export default {
   horizontal_divider: HorizontalDivider,
   product_grid: ProductGrid
 }
+
+export default () => Object.assign({}, defaultTemplates, Config.get().customTemplateComponents)

--- a/src/index.js
+++ b/src/index.js
@@ -31,7 +31,7 @@ export { default as VariantSelector } from './objects/variant-selector'
 /**
  * Template Components
  */
-export { default as TemplateComponentsManifest } from './components/template-components/_manifest'
+export { default as buildTemplateComponentsManifest } from './components/template-components/_manifest'
 
 /**
  * Account Components


### PR DESCRIPTION
Related issue https://github.com/shiftcommerce/shift-front-end-react/issues/781

Allows definition of custom template components in the config, e.g.:
```
Config.set({
  customTemplateComponents: {
    'custom-text-line': CustomTextLine
  }
})
```

The template components manifest is now a function so the manifest is built at runtime rather than compile time (the config is empty at compile time) - a relevant PR for shift-next will follow.